### PR TITLE
Bind SpacedShapeString edit dialog to expression editor

### DIFF
--- a/freecad/ShapeStrings/Spaced/Dialog.py
+++ b/freecad/ShapeStrings/Spaced/Dialog.py
@@ -352,6 +352,14 @@ class SpacedShapeStringTaskPanelEdit(SpacedShapeStringTaskPanel):
         self.vobj = vobj
         self.call = Gui.activeView().addEventCallback("SoEvent", self.action)
 
+        # Bind the numeric fields to their document object properties so the
+        # "=" shortcut and "fx" icon open FreeCAD's expression editor.
+        Gui.ExpressionBinding(self.form.sbX).bind(vobj.Object, "Placement.Base.x")
+        Gui.ExpressionBinding(self.form.sbY).bind(vobj.Object, "Placement.Base.y")
+        Gui.ExpressionBinding(self.form.sbZ).bind(vobj.Object, "Placement.Base.z")
+        Gui.ExpressionBinding(self.form.sbHeight).bind(vobj.Object, "Size")
+        Gui.ExpressionBinding(self.form.sbOffset).bind(vobj.Object, "Offset")
+
     def accept(self):
         x = App.Units.Quantity(self.form.sbX.text()).Value
         y = App.Units.Quantity(self.form.sbY.text()).Value


### PR DESCRIPTION
## Summary
- Implements Option A from `AI-planning/issue-08-expression-editor-access.md` for #8
- Binds `sbX`/`sbY`/`sbZ`/`sbHeight`/`sbOffset` on `SpacedShapeStringTaskPanelEdit` to `Placement.Base.x/y/z`, `Size`, and `Offset` via `Gui.ExpressionBinding(widget).bind(obj, "Path")`, so the `=` shortcut and "fx" icon open FreeCAD's expression editor in edit mode
- Create mode is intentionally left unbound (no object exists yet at dialog-open time), matching the proposal's scoped recommendation

## Test plan
- [ ] Open FreeCAD, edit an existing `SpacedShapeString`, confirm the dialog opens without error for all five bound fields
- [ ] Confirm the `=` shortcut and "fx" icon appear on `sbX`, `sbY`, `sbZ`, `sbHeight`, `sbOffset`
- [ ] Set an expression (e.g. `Size = 5+5`) via the fx dialog, click OK, reopen, and confirm the expression persisted
- [ ] Repeat for `Placement.Base.x`, since `accept()` writes the whole `Placement.Base` vector as a literal before the trailing `recompute()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)