### PR TITLE
Add Columns and RowSpacing to SpacedShapeString

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -30,7 +30,9 @@ Spaced(
     FontFile = ... ,
     String = ... ,
     Offset = ... ,
-    Size = ...
+    Size = ... ,
+    Columns = ... ,
+    RowSpacing = ...
 )
 ```
 

--- a/Documentation/Commands/Spaced.md
+++ b/Documentation/Commands/Spaced.md
@@ -72,6 +72,18 @@ The result is a regular FreeCAD shape object that works with
     and the start of the next is kept equal to the offset,  
     using each string’s bounding box to measure its width.
 
+-   `Columns`  
+    Number of strings per row before wrapping to a new row.  
+    `0` keeps every string on a single row (the default,  
+    unchanged from previous versions). Empty entries in  
+    `Strings` are skipped entirely and do not occupy a  
+    grid cell, matching how they behave in a single row.
+
+-   `RowSpacing`  
+    Vertical spacing applied between rows, used only when  
+    `Columns` is greater than `0`. Rows advance downward  
+    (in -Y) from the first row.
+
 <br/>
 
 ## Creation
@@ -107,7 +119,11 @@ The result is a regular FreeCAD shape object that works with
     *Set the bounding box option*  
     *to space strings by their width.*
 
-    F.  Finish the operation by  
+    F.  Optionally set `Columns` and  
+        `Row Spacing` to wrap the strings  
+        onto a grid instead of a single row.
+
+    G.  Finish the operation by  
         clicking the `Ok` button.
 
 <br/>
@@ -123,8 +139,10 @@ from ShapeStrings import Spaced
 Spaced(
     UseBoundingBox = False ,
     FontFile = '/path/to/font.ttf' ,
-    Strings = [ 'String1' , 'String2' ] ,
+    Strings = [ 'String1' , 'String2' , 'String3' , 'String4' ] ,
     Offset = 5 ,
     Size = 10 ,
+    Columns = 2 ,
+    RowSpacing = 15 ,
 )
 ```

--- a/freecad/ShapeStrings/Resources/Interfaces/Spaced.ui
+++ b/freecad/ShapeStrings/Resources/Interfaces/Spaced.ui
@@ -200,13 +200,59 @@ Uncheck to use working plane coordinate system</string>
       </widget>
      </item>
      <item row="4" column="0">
+      <widget class="QLabel" name="labelColumns">
+       <property name="text">
+        <string>Columns</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="sbColumns">
+       <property name="toolTip">
+        <string>Number of strings per row before wrapping to a new row (0 = single row)</string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>999999</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelRowSpacing">
+       <property name="text">
+        <string>Row Spacing</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbRowSpacing">
+       <property name="toolTip">
+        <string>Spacing between rows, used when Columns is greater than 0</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
       <widget class="QLabel" name="labelFontFile">
        <property name="text">
         <string>Font file</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="6" column="1">
       <widget class="Gui::FileChooser" name="fcFontFile">
        <property name="filter">
         <string>Font files (*.ttc *.ttf *.otf *.pfb *.TTC *.TTF *.OTF *.PFB)</string>

--- a/freecad/ShapeStrings/Spaced/Dialog.py
+++ b/freecad/ShapeStrings/Spaced/Dialog.py
@@ -59,7 +59,9 @@ class SpacedShapeStringTaskPanel:
                  strings=None,
                  offset=10.0,
                  use_bounding_box=False,
-                 font=""):
+                 font="",
+                 columns=0,
+                 row_spacing=10.0):
 
         if strings is None:
             strings = []
@@ -100,6 +102,11 @@ class SpacedShapeStringTaskPanel:
         self.form.sbOffset.setProperty("rawValue", offset)
         self.form.sbOffset.setProperty("unit", unit_length)
         self.form.cbUseBoundingBox.setChecked(bool(use_bounding_box))
+
+        # Columns and RowSpacing controls
+        self.form.sbColumns.setValue(int(columns))
+        self.form.sbRowSpacing.setProperty("rawValue", row_spacing)
+        self.form.sbRowSpacing.setProperty("unit", unit_length)
 
         # Platform dialog setup
         self.platWinDialog("Overwrite")
@@ -299,6 +306,8 @@ class SpacedShapeStringTaskPanelCmd(SpacedShapeStringTaskPanel):
         Size = str(App.Units.Quantity(self.form.sbHeight.text()).Value)
         Offset = str(App.Units.Quantity(self.form.sbOffset.text()).Value)
         UseBoundingBox = str(bool(self.form.cbUseBoundingBox.isChecked()))
+        Columns = str(int(self.form.sbColumns.value()))
+        RowSpacing = str(App.Units.Quantity(self.form.sbRowSpacing.text()).Value)
 
         # Base point
         x = App.Units.Quantity(self.form.sbX.text()).Value
@@ -316,7 +325,8 @@ class SpacedShapeStringTaskPanelCmd(SpacedShapeStringTaskPanel):
                     f"ss = {c}.Spaced("
                     f"Strings={string_list_expr}, "
                     f"FontFile={FFile}, Size={Size}, Offset={Offset}, "
-                    f"UseBoundingBox={UseBoundingBox})"
+                    f"UseBoundingBox={UseBoundingBox}, "
+                    f"Columns={Columns}, RowSpacing={RowSpacing})"
                 ),
                 "plm = FreeCAD.Placement()",
                 f"plm.Base = {toString(ssBase)}",
@@ -345,8 +355,10 @@ class SpacedShapeStringTaskPanelEdit(SpacedShapeStringTaskPanel):
         offset = vobj.Object.Offset.Value
         use_bounding_box = bool(getattr(vobj.Object, "UseBoundingBox", False))
         font = vobj.Object.FontFile
+        columns = int(getattr(vobj.Object, "Columns", 0))
+        row_spacing = getattr(vobj.Object, "RowSpacing", App.Units.Quantity(10.0, App.Units.Length)).Value
 
-        super().__init__(base, size, strings, offset, use_bounding_box, font)
+        super().__init__(base, size, strings, offset, use_bounding_box, font, columns, row_spacing)
 
         self.pointPicked = True
         self.vobj = vobj
@@ -362,6 +374,8 @@ class SpacedShapeStringTaskPanelEdit(SpacedShapeStringTaskPanel):
         strings = self.collectStrings()
         offset = App.Units.Quantity(self.form.sbOffset.text()).Value
         use_bounding_box = bool(self.form.cbUseBoundingBox.isChecked())
+        columns = int(self.form.sbColumns.value())
+        row_spacing = App.Units.Quantity(self.form.sbRowSpacing.text()).Value
         font_file = self.fileSpec
 
         o = 'FreeCAD.ActiveDocument.getObject("{}")'.format(self.vobj.Object.Name)
@@ -370,6 +384,8 @@ class SpacedShapeStringTaskPanelEdit(SpacedShapeStringTaskPanel):
         Gui.doCommand(o + ".Strings=" + repr(strings))
         Gui.doCommand(o + ".Offset=" + str(offset))
         Gui.doCommand(o + ".UseBoundingBox=" + str(use_bounding_box))
+        Gui.doCommand(o + ".Columns=" + str(columns))
+        Gui.doCommand(o + ".RowSpacing=" + str(row_spacing))
         Gui.doCommand(o + '.FontFile="' + font_file + '"')
         Gui.doCommand("FreeCAD.ActiveDocument.recompute()")
 

--- a/freecad/ShapeStrings/Spaced/Generator.py
+++ b/freecad/ShapeStrings/Spaced/Generator.py
@@ -35,13 +35,16 @@ if App.GuiUp:
     from .View import ViewProviderSpacedShapeString
 
 
-def make_spacedshapestring(Strings, FontFile, Size=100, Offset=10, UseBoundingBox=False):
-    """SpacedShapeString(Strings,FontFile,[Height],[Offset],[UseBoundingBox])
+def make_spacedshapestring(Strings, FontFile, Size=100, Offset=10, UseBoundingBox=False,
+                            Columns=0, RowSpacing=10):
+    """SpacedShapeString(Strings,FontFile,[Height],[Offset],[UseBoundingBox],[Columns],[RowSpacing])
 
     Turns a list of text strings into a single Compound Shape, with each
     string rendered using the given font and separated in the x-direction
     by the specified offset (and optionally using each string's bounding
-    box width to compute spacing).
+    box width to compute spacing). If Columns is greater than 0, the
+    strings wrap to a new row every Columns entries, with rows separated
+    by RowSpacing in the y-direction.
     """
     App.Console.PrintMessage("Creating SpacedShapeString object...\n")
 
@@ -60,6 +63,8 @@ def make_spacedshapestring(Strings, FontFile, Size=100, Offset=10, UseBoundingBo
     obj.Size = Size
     obj.Offset = Offset
     obj.UseBoundingBox = bool(UseBoundingBox)
+    obj.Columns = int(Columns)
+    obj.RowSpacing = RowSpacing
 
     # Print all object properties to the FreeCAD console
     App.Console.PrintMessage("SpacedShapeString properties:\n")

--- a/freecad/ShapeStrings/Spaced/Object.py
+++ b/freecad/ShapeStrings/Spaced/Object.py
@@ -67,6 +67,16 @@ class SpacedShapeString(DraftObject):
             obj.addProperty("App::PropertyBool", "UseBoundingBox", "Draft", _tip)
             obj.UseBoundingBox = False
 
+        if "Columns" not in properties:
+            _tip = translate("App::Property", "Number of strings per row before wrapping to a new row (0 = single row)")
+            obj.addProperty("App::PropertyInteger", "Columns", "Draft", _tip)
+            obj.Columns = 0
+
+        if "RowSpacing" not in properties:
+            _tip = translate("App::Property", "Y-direction spacing between rows, used when Columns is greater than 0")
+            obj.addProperty("App::PropertyLength", "RowSpacing", "Draft", _tip)
+            obj.RowSpacing = 10.0
+
         if "FontFile" not in properties:
             _tip = translate("App::Property", "Font file name")
             obj.addProperty("App::PropertyFile", "FontFile", "Draft", _tip)
@@ -133,6 +143,8 @@ class SpacedShapeString(DraftObject):
             plm = obj.Placement
             all_shapes = []
             x_offset = App.Units.Quantity(0, App.Units.Length)  # 0 mm
+            y_offset = App.Units.Quantity(0, App.Units.Length)  # 0 mm
+            rendered_count = 0  # count of strings actually rendered, used for row wrapping
 
             # Pre-calculate justification vector once (same for all strings)
             # Create a test shape to get justification parameters
@@ -142,7 +154,7 @@ class SpacedShapeString(DraftObject):
                 cap_height = obj.Size
 
             # Process each string in the list
-            for string_index, string_text in enumerate(obj.Strings):
+            for string_text in obj.Strings:
                 if not string_text:
                     continue
 
@@ -202,12 +214,16 @@ class SpacedShapeString(DraftObject):
                     for shape in shapes:
                         shape.translate(just_vec)
 
-                    # Apply x-direction offset for this string
-                    # (first string has no offset applied)
-                    if string_index > 0:
-                        offset_vec = App.Vector(x_offset, 0, 0)
-                        for shape in shapes:
-                            shape.translate(offset_vec)
+                    # Wrap to a new row every `Columns` rendered strings
+                    # (rows advance in -Y, so RowSpacing accumulates downward)
+                    if obj.Columns > 0 and rendered_count > 0 and rendered_count % obj.Columns == 0:
+                        x_offset = App.Units.Quantity(0, App.Units.Length)
+                        y_offset -= obj.RowSpacing
+
+                    # Apply x/y-direction offset for this string
+                    offset_vec = App.Vector(x_offset, y_offset, 0)
+                    for shape in shapes:
+                        shape.translate(offset_vec)
 
                     # Calculate spacing for next string if UseBoundingBox is enabled
                     _toolmsg("type x_offset: {} repr: {}".format(type(x_offset), repr(x_offset)))
@@ -223,6 +239,7 @@ class SpacedShapeString(DraftObject):
                     x_offset += obj.Offset
 
                     all_shapes.extend(shapes)
+                    rendered_count += 1
 
             if all_shapes:
                 obj.Shape = Part.Compound(all_shapes)


### PR DESCRIPTION
## Summary
- Adds `Columns` (`App::PropertyInteger`, default `0`) and `RowSpacing` (`App::PropertyLength`, default `10.0`) properties to `SpacedShapeString`, implementing Option A from `AI-planning/issue-09-grid-columns-interline-spacing.md`.
- Strings wrap to a new row every `Columns` entries; rows advance downward (`-Y`) by `RowSpacing`. `Columns = 0` keeps the existing single-row behavior, so old documents/macros are unaffected.
- Wires the new fields through the create/edit task panel dialogs and `.ui` layout, the `ShapeStrings.Spaced()` Python API, and the `Documentation/Commands/Spaced.md` / `Documentation/API.md` docs per `AGENTS.md` conventions.

Closes #9

## Test plan
- [x] `python3 -m py_compile` on all changed `.py` files
- [x] Validated `Spaced.ui` is well-formed XML
- [x] Standalone simulation of the row/column wrap arithmetic (Columns=0 single-row behavior unchanged; Columns=2/3 wrap correctly)
- [x] Confirmed against FreeCAD's `draftobjects/base.py` that changing `Columns`/`RowSpacing` triggers a full recompute (not treated as a placement-only change)
- [ ] Manual verification inside FreeCAD's Draft workbench (no FreeCAD GUI available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)