### PR TITLE
Add Grid ShapeString: wrap strings onto a 2D grid

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -2,7 +2,7 @@
 # API
 
 This addon exposes a small API to let you  
-create Spaced & Radial ShapeStrings via Python.
+create Spaced, Radial & Grid ShapeStrings via Python.
 
 <br/>
 
@@ -28,7 +28,7 @@ from ShapeStrings import Spaced
 Spaced(
     UseBoundingBox = ... ,
     FontFile = ... ,
-    String = ... ,
+    Strings = ... ,
     Offset = ... ,
     Size = ...
 )
@@ -62,5 +62,28 @@ Radial(
 
 
 
+## Grid
+
+Create a Grid ShapeString object with:
+
+```Python
+from ShapeStrings import Grid
+
+Grid(
+    UseBoundingBox = ... ,
+    FontFile = ... ,
+    Strings = ... ,
+    Columns = ... ,
+    ColumnOffset = ... ,
+    RowOffset = ... ,
+    Size = ... ,
+)
+```
+
+[» Read more about it here.][Grid]
+
+
+
 [Spaced]: ./Commands/Spaced.md
 [Radial]: ./Commands/Radial.md
+[Grid]: ./Commands/Grid.md

--- a/Documentation/Commands/Grid.md
+++ b/Documentation/Commands/Grid.md
@@ -1,0 +1,123 @@
+
+## <img height = '24' src = '../../freecad/ShapeStrings/Resources/Icons/Grid.svg' /> Grid ShapeString
+
+Lets you wrap multiple strings onto a 2D grid of rows and columns.
+
+Set how many columns wide the grid is; once that many strings have  
+been placed, layout wraps to a new row underneath. Column and row  
+spacing are configured independently, so rows don't have to be as  
+tightly packed as columns (or vice versa).
+
+Leaving an entry blank still reserves its position in the grid - use  
+this to leave gaps, e.g. for an L-shaped layout of labelled tiles.
+
+The result is a regular FreeCAD shape object that works with  
+**Part** and **PartDesign** operations for engraving or embossing.
+
+<br/>
+
+## Use Cases
+
+-   **Labelled tile plaques**  
+    Laying out a grid of distinct labels for tiles, keys, or panels  
+    that will be engraved or embossed as a single plate.
+
+-   **Keypad legends**  
+    Generating the row/column legends for a keypad or button panel  
+    where each position needs its own text.
+
+-   **Reference/lookup grids**  
+    Producing a small grid of codes, coordinates, or index labels  
+    (e.g. "A1", "A2", "B1", "B2", ...) for a jig or fixture.
+
+-   **Sparse/irregular layouts**  
+    Leaving some grid positions blank to lay out an L-shaped or  
+    otherwise irregular arrangement of labels within a rectangular grid.
+
+<br/>
+
+## Properties
+
+-   `Strings`  
+    List of text entries to render, read row-major (left to right,  
+    then wrapping to the next row down). A blank entry still occupies  
+    its grid position - it just renders nothing there.
+
+-   `Columns`  
+    Number of columns before layout wraps to a new row.
+
+-   `FontFile`   
+    Path to the font file used for rendering.  
+    Examples : `.ttf` or `.otf` files
+
+-   `Size`  
+    Height of the rendered text, in model units.
+
+-   `ColumnOffset`  
+    Horizontal spacing value applied between columns.
+
+-   `RowOffset`  
+    Vertical spacing value applied between rows. Rows stack downward  
+    (in -Y) as `Strings` is read from the start, matching reading order.
+
+-   `UseBoundingBox`  
+    Controls how `ColumnOffset`/`RowOffset` are interpreted:
+    - `False` : Columns/rows are placed at a fixed pitch  
+    (`ColumnOffset`/`RowOffset` apart), regardless of character widths.  
+    - `True` : Each column is sized to its widest string and each row  
+    to its tallest string, with `ColumnOffset`/`RowOffset` added as the  
+    visible gap on top of that.
+
+<br/>
+
+## Creation
+
+1.  Navigate to the `Draft` workbench.
+
+2.  Click the <img height = '16' src = '../../freecad/ShapeStrings/Resources/Icons/Grid.svg' /> `Grid ShapeString` action.
+
+    *A task panel should open*
+
+3.  In the task panel do the following:
+
+    A.  Select the object position.
+
+    B.  Set the number of columns.
+
+    C.  Fill in the strings table - one cell per grid position.  
+        Use `Add Row` / `Remove Row` to grow or shrink the grid, and  
+        leave a cell blank to skip that position. Changing the column  
+        count reflows the existing entries into the new shape.
+
+    D.  Select the file of the font.
+
+    E.  Adjust the font size / height.
+
+    F.  Configure the column offset and row offset.
+
+    *Set the bounding box option*  
+    *to size columns/rows by their content instead of a fixed pitch.*
+
+    G.  Finish the operation by  
+        clicking the `Ok` button.
+
+<br/>
+
+## Python
+
+To run the following code, paste it into FreeCAD's  
+Python console while you have a document open.
+
+```Python
+from ShapeStrings import Grid
+
+Grid(
+    UseBoundingBox = False ,
+    FontFile = '/path/to/font.ttf' ,
+    Strings = [ 'A1' , 'A2' , 'A3' , 'B1' , 'B2' , 'B3' ] ,
+    Columns = 3 ,
+    ColumnOffset = 5 ,
+    RowOffset = 8 ,
+    Size = 10 ,
+)
+```

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -11,7 +11,10 @@
 
 -   [How to use the **Radial** command][Radial]
 
+-   [How to use the **Grid** command][Grid]
+
 
 [Spaced]: ./Commands/Spaced.md
 [Radial]: ./Commands/Radial.md
+[Grid]: ./Commands/Grid.md
 [API]: ./API.md

--- a/freecad/ShapeStrings/API/Module.py
+++ b/freecad/ShapeStrings/API/Module.py
@@ -3,3 +3,4 @@
 
 from ..Radial.Generator import make_radialshapestring as Radial
 from ..Spaced.Generator import make_spacedshapestring as Spaced
+from ..Grid.Generator import make_gridshapestring as Grid

--- a/freecad/ShapeStrings/Grid/Command.py
+++ b/freecad/ShapeStrings/Grid/Command.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2009 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2009 Ken Cline <cline@frii.com>
+# SPDX-FileCopyrightText: 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Provides GUI tools to create grid-arranged text shapes with a particular font.
+
+These text shapes are made of various edges and closed faces, and therefore
+can be extruded to create solid bodies that can be used in boolean
+operations. That is, these text shapes can be used for engraving text
+into solid bodies.
+
+They are more complex than simple text annotations, and support multiple
+strings wrapped onto a 2D grid of rows and columns.
+"""
+
+
+import FreeCADGui as Gui
+import Draft_rc
+import draftguitools.gui_base_original as gui_base_original
+import draftutils.todo as todo
+
+from ..Misc.Resources import asIcon
+from .Dialog import GridShapeStringTaskPanelCmd
+from draftutils.messages import _toolmsg
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+from FreeCAD import Qt
+
+translate = Qt.translate
+
+
+class GridShapeString(gui_base_original.Creator):
+    """Gui command for the GridShapeString tool."""
+
+    def GetResources(self):
+        """Set icon, menu, and tooltip."""
+        return {
+            'Pixmap': asIcon('Grid'),
+            'MenuText': translate(
+                "ShapeStrings-Grid",
+                "Grid ShapeString"
+            ),
+            'ToolTip': translate(
+                "ShapeStrings-Grid",
+                "Creates multiple ShapeStrings from a list of text entries, "
+                "wrapped onto a 2D grid after a configurable number of columns. "
+                "Column and row spacing can be fixed, or adjusted for visible gaps "
+                "using each string's bounding box. "
+                "Useful for laying out labelled tiles, keypads, or plaques for Part and PartDesign operations."
+            ),
+        }
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated(name="GridShapeString")
+        if self.ui:
+            self.ui = Gui.draftToolBar
+            self.sourceCmd = self
+            self.task = GridShapeStringTaskPanelCmd(self)
+            self.call = self.view.addEventCallback("SoEvent", self.task.action)
+            _toolmsg(translate("draft", "Pick GridShapeString location point"))
+            todo.ToDo.delay(Gui.Control.showDialog, self.task)
+
+    def finish(self):
+        """Finalize the command and remove callbacks."""
+
+        if not hasattr(self, 'planetrack'):
+            self.planetrack = None
+        if hasattr(self, 'call'):
+            self.end_callbacks(self.call)
+        if not hasattr(self, 'ui'):
+            self.ui = Gui.draftToolBar
+        super().finish()
+
+def registerGrid():
+    Gui.addCommand('ShapeStrings_Grid', GridShapeString())

--- a/freecad/ShapeStrings/Grid/Dialog.py
+++ b/freecad/ShapeStrings/Grid/Dialog.py
@@ -387,6 +387,16 @@ class GridShapeStringTaskPanelEdit(GridShapeStringTaskPanel):
         self.vobj = vobj
         self.call = Gui.activeView().addEventCallback("SoEvent", self.action)
 
+        # Bind the numeric fields to their document object properties so the
+        # "=" shortcut and "fx" icon open FreeCAD's expression editor.
+        Gui.ExpressionBinding(self.form.sbX).bind(vobj.Object, "Placement.Base.x")
+        Gui.ExpressionBinding(self.form.sbY).bind(vobj.Object, "Placement.Base.y")
+        Gui.ExpressionBinding(self.form.sbZ).bind(vobj.Object, "Placement.Base.z")
+        Gui.ExpressionBinding(self.form.sbHeight).bind(vobj.Object, "Size")
+        Gui.ExpressionBinding(self.form.sbColumns).bind(vobj.Object, "Columns")
+        Gui.ExpressionBinding(self.form.sbColumnOffset).bind(vobj.Object, "ColumnOffset")
+        Gui.ExpressionBinding(self.form.sbRowOffset).bind(vobj.Object, "RowOffset")
+
     def accept(self):
         x = App.Units.Quantity(self.form.sbX.text()).Value
         y = App.Units.Quantity(self.form.sbY.text()).Value

--- a/freecad/ShapeStrings/Grid/Dialog.py
+++ b/freecad/ShapeStrings/Grid/Dialog.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2009 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>
+# SPDX-FileCopyrightText: 2025 FreeCAD Project Association
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Provides the task panel code for the Draft GridShapeString tool."""
+
+import traceback
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+import Draft_rc
+
+from draftguitools import gui_tool_utils
+from draftutils.messages import _err, _msg
+from draftutils.params import get_param
+from draftutils.translate import translate
+from DraftVecUtils import toString
+
+from ..Misc.Resources import asIcon , asUI
+
+
+# So the resource file doesn't trigger errors from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+# Parameter groups for preferences
+ADV_PARAM_GROUP = "User parameter:BaseApp/Preferences/Mod/ShapeStrings"
+
+class GridShapeStringTaskPanel:
+    """Base class for grid task panel."""
+
+    def __init__(self,
+                 point=App.Vector(0, 0, 0),
+                 size=10,
+                 strings=None,
+                 columns=3,
+                 column_offset=10.0,
+                 row_offset=15.0,
+                 use_bounding_box=False,
+                 font=""):
+
+        columns = max(1, int(columns))
+
+        if not strings:
+            # Provide a single default editable cell, same spirit as
+            # SpacedShapeString's default list entry.
+            strings = [translate("draft", "Default")]
+
+        # Load custom UI for grid shapestring
+        self.form = Gui.PySideUic.loadUi(asUI('Grid'))
+        self.form.setObjectName("GridShapeStringTaskPanel")
+        self.form.setWindowTitle(translate("draft", "GridShapeString"))
+        self.form.setWindowIcon(QtGui.QIcon(asIcon('Grid')))
+
+        unit_length = App.Units.Quantity(0.0, App.Units.Length).getUserPreferred()[2]
+
+        self.form.sbX.setProperty("rawValue", point.x)
+        self.form.sbX.setProperty("unit", unit_length)
+        self.form.sbY.setProperty("rawValue", point.y)
+        self.form.sbY.setProperty("unit", unit_length)
+        self.form.sbZ.setProperty("rawValue", point.z)
+        self.form.sbZ.setProperty("unit", unit_length)
+
+        self.form.sbHeight.setProperty("rawValue", size)
+        self.form.sbHeight.setProperty("unit", unit_length)
+
+        # Columns and the 2D strings table
+        self.form.sbColumns.setValue(columns)
+        self._populateTable(strings, columns)
+
+        # ColumnOffset, RowOffset and UseBoundingBox controls
+        self.form.sbColumnOffset.setProperty("rawValue", column_offset)
+        self.form.sbColumnOffset.setProperty("unit", unit_length)
+        self.form.sbRowOffset.setProperty("rawValue", row_offset)
+        self.form.sbRowOffset.setProperty("unit", unit_length)
+        self.form.cbUseBoundingBox.setChecked(bool(use_bounding_box))
+
+        # Platform dialog setup
+        self.platWinDialog("Overwrite")
+
+        # Parameter groups
+        self._adv_params = App.ParamGet(ADV_PARAM_GROUP)
+
+        # Font file: Shapestring default → Draft default → explicit arg → empty
+        if font:
+            self.fileSpec = font
+        else:
+            adv_font = self._adv_params.GetString("FontFile", "")
+            if adv_font:
+                self.fileSpec = adv_font
+            else:
+                # Use existing Draft preference helper as final fallback
+                self.fileSpec = get_param("FontFile") or ""
+
+        self.form.fcFontFile.setFileName(self.fileSpec)
+
+        self.point = point
+        self.pointPicked = False
+
+        # Default for the "DontUseNativeFontDialog" preference:
+        self.font_dialog_pref = False
+
+        # Dummy attribute used by gui_tool_utils.getPoint in action method
+        self.node = None
+
+        QtCore.QObject.connect(
+            self.form.fcFontFile,
+            QtCore.SIGNAL("fileNameSelected(const QString&)"),
+            self.fileSelect,
+        )
+
+        QtCore.QObject.connect(
+            self.form.pbReset,
+            QtCore.SIGNAL("clicked()"),
+            self.resetPoint,
+        )
+
+        QtCore.QObject.connect(
+            self.form.pbAddRow,
+            QtCore.SIGNAL("clicked()"),
+            self.addRow,
+        )
+        QtCore.QObject.connect(
+            self.form.pbRemoveRow,
+            QtCore.SIGNAL("clicked()"),
+            self.removeRow,
+        )
+        QtCore.QObject.connect(
+            self.form.sbColumns,
+            QtCore.SIGNAL("valueChanged(int)"),
+            self.columnsChanged,
+        )
+
+    def fileSelect(self, fn):
+        """Assign the selected file and remember it as default for ShapeStrings."""
+        self.fileSpec = fn
+        # Ensure parameter group exists
+        if not hasattr(self, "_adv_params"):
+            self._adv_params = App.ParamGet(ADV_PARAM_GROUP)
+        # Store last-used font as mod preference
+        self._adv_params.SetString("FontFile", str(fn))
+
+    def resetPoint(self):
+        """Reset the selected point."""
+        self.pointPicked = False
+        origin = App.Vector(0.0, 0.0, 0.0)
+        self.setPoint(origin)
+
+    def _populateTable(self, texts, columns):
+        """(Re)build tableStrings as a `columns`-wide grid holding `texts`
+        row-major, padding any remaining cells with empty, editable items."""
+        table = self.form.tableStrings
+        table.blockSignals(True)
+        table.clear()
+        table.horizontalHeader().setVisible(False)
+        table.verticalHeader().setVisible(False)
+        table.setColumnCount(columns)
+        row_count = max(1, -(-len(texts) // columns)) if texts else 1
+        table.setRowCount(row_count)
+
+        for index, text in enumerate(texts):
+            row, col = index // columns, index % columns
+            table.setItem(row, col, QtGui.QTableWidgetItem(text))
+
+        for row in range(table.rowCount()):
+            for col in range(table.columnCount()):
+                if table.item(row, col) is None:
+                    table.setItem(row, col, QtGui.QTableWidgetItem(""))
+
+        table.blockSignals(False)
+
+    def columnsChanged(self, new_columns):
+        """Reshape the table when the Columns spin box changes."""
+        new_columns = max(1, int(new_columns))
+        texts = self._collectTableTexts()
+        self._populateTable(texts, new_columns)
+
+    def _collectTableTexts(self):
+        """Flatten tableStrings row-major, one entry per cell (blanks kept)."""
+        table = self.form.tableStrings
+        texts = []
+        for row in range(table.rowCount()):
+            for col in range(table.columnCount()):
+                item = table.item(row, col)
+                texts.append(item.text().strip() if item else "")
+        return texts
+
+    def addRow(self):
+        """Append a new blank row of cells to tableStrings."""
+        table = self.form.tableStrings
+        row = table.rowCount()
+        table.insertRow(row)
+        for col in range(table.columnCount()):
+            table.setItem(row, col, QtGui.QTableWidgetItem(""))
+        self.updateRemoveRowButtonState()
+
+    def removeRow(self):
+        """Remove the currently selected row from tableStrings, if more than one remains."""
+        table = self.form.tableStrings
+        if table.rowCount() <= 1:
+            return  # Do not allow removing the last remaining row
+
+        row = table.currentRow()
+        if row < 0:
+            row = table.rowCount() - 1
+        table.removeRow(row)
+        self.updateRemoveRowButtonState()
+
+    def updateRemoveRowButtonState(self):
+        """Enable/disable the Remove Row button depending on the number of rows."""
+        table = self.form.tableStrings
+        self.form.pbRemoveRow.setEnabled(table.rowCount() > 1)
+
+    def collectStrings(self):
+        """Read strings from tableStrings, row-major. Interior blank cells
+        are kept (they mark an empty grid position); only a trailing run
+        of blanks is trimmed off the end of the list."""
+        texts = self._collectTableTexts()
+        while texts and not texts[-1]:
+            texts.pop()
+        return texts
+
+    def collectColumns(self):
+        """Read the configured column count."""
+        return max(1, int(self.form.sbColumns.value()))
+
+    def action(self, arg):
+        """Scene event handler."""
+        if arg["Type"] == "SoKeyboardEvent":
+            if arg["Key"] == "ESCAPE":
+                self.reject()
+        elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
+            self.point, ctrlPoint, info = gui_tool_utils.getPoint(
+                self, arg, noTracker=True
+            )
+            if not self.pointPicked:
+                self.setPoint(self.point)
+        elif arg["Type"] == "SoMouseButtonEvent":
+            if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
+                self.setPoint(self.point)
+                self.pointPicked = True
+
+    def setPoint(self, point):
+        """Assign the selected point."""
+        self.form.sbX.setProperty("rawValue", point.x)
+        self.form.sbY.setProperty("rawValue", point.y)
+        self.form.sbZ.setProperty("rawValue", point.z)
+
+    def platWinDialog(self, flag):
+        """Handle the type of dialog depending on the platform."""
+        ParamGroup = App.ParamGet("User parameter:BaseApp/Preferences/Dialog")
+
+        if flag == "Overwrite":
+            if "DontUseNativeFontDialog" not in ParamGroup.GetBools():
+                # initialize nonexisting one
+                ParamGroup.SetBool("DontUseNativeFontDialog", True)
+            param = ParamGroup.GetBool("DontUseNativeFontDialog")
+            self.font_dialog_pref = ParamGroup.GetBool("DontUseNativeDialog")
+            ParamGroup.SetBool("DontUseNativeDialog", param)
+
+        elif flag == "Restore":
+            ParamGroup.SetBool("DontUseNativeDialog", self.font_dialog_pref)
+
+
+class GridShapeStringTaskPanelCmd(GridShapeStringTaskPanel):
+    """Task panel for the grid command."""
+
+    def __init__(self, sourceCmd):
+        super().__init__()
+        self.sourceCmd = sourceCmd
+
+    def accept(self):
+        """Execute when clicking the OK button."""
+        # Persist font used in this operation as AdvancedShapestring default
+        if not hasattr(self, "_adv_params"):
+            self._adv_params = App.ParamGet(ADV_PARAM_GROUP)
+        self._adv_params.SetString("FontFile", str(self.fileSpec))
+
+        self.createObject()
+        self.reject()
+        return True
+
+    def reject(self):
+        """Run when clicking the Cancel button."""
+        Gui.ActiveDocument.resetEdit()
+        self.sourceCmd.finish()
+        self.platWinDialog("Restore")
+        return True
+
+    def createObject(self):
+        """Create GridShapeString object in the current document."""
+
+        # Strings and grid layout
+        strings = self.collectStrings()
+        columns = self.collectColumns()
+
+        # Escape each for Python string literal usage
+        string_list_expr = "[" + ", ".join(
+            ['"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"' for s in strings]
+        ) + "]"
+
+        # Font file
+        FFile = '"' + str(self.fileSpec) + '"'
+
+        # Size and spacing
+        Size = str(App.Units.Quantity(self.form.sbHeight.text()).Value)
+        ColumnOffset = str(App.Units.Quantity(self.form.sbColumnOffset.text()).Value)
+        RowOffset = str(App.Units.Quantity(self.form.sbRowOffset.text()).Value)
+        UseBoundingBox = str(bool(self.form.cbUseBoundingBox.isChecked()))
+
+        # Base point
+        x = App.Units.Quantity(self.form.sbX.text()).Value
+        y = App.Units.Quantity(self.form.sbY.text()).Value
+        z = App.Units.Quantity(self.form.sbZ.text()).Value
+        ssBase = App.Vector(x, y, z)
+
+        try:
+            qr, sup, points, fil = self.sourceCmd.getStrings()
+            c = "ShapeStrings"
+            Gui.addModule("Draft")
+            Gui.addModule(f"{c}")
+            commands = [
+                (
+                    f"ss = {c}.Grid("
+                    f"Strings={string_list_expr}, "
+                    f"FontFile={FFile}, Size={Size}, Columns={columns}, "
+                    f"ColumnOffset={ColumnOffset}, RowOffset={RowOffset}, "
+                    f"UseBoundingBox={UseBoundingBox})"
+                ),
+                "plm = FreeCAD.Placement()",
+                f"plm.Base = {toString(ssBase)}",
+                f"plm.Rotation.Q = {qr}",
+                "ss.Placement = plm",
+                f"ss.AttachmentSupport = {sup}",
+                "Draft.autogroup(ss)", # Requires the "Draft" module
+                "FreeCAD.ActiveDocument.recompute()",
+            ]
+            # Print the commands that will be passed to commit for debugging/logging
+            _msg("Grid ShapeString commit commands:\n" + "\n".join(commands))
+            self.sourceCmd.commit(translate("draft", "Create Grid ShapeString"), commands)
+        except Exception:
+            _err("Grid ShapeString : error delaying commit\n")
+            # Also print the full Python traceback to the console/log
+            traceback.print_exc()
+
+
+class GridShapeStringTaskPanelEdit(GridShapeStringTaskPanel):
+    """Task panel for Draft GridShapeString object in edit mode."""
+
+    def __init__(self, vobj):
+        base = vobj.Object.Placement.Base
+        size = vobj.Object.Size.Value
+        columns = vobj.Object.Columns
+        strings = list(vobj.Object.Strings)
+        column_offset = vobj.Object.ColumnOffset.Value
+        row_offset = vobj.Object.RowOffset.Value
+        use_bounding_box = bool(getattr(vobj.Object, "UseBoundingBox", False))
+        font = vobj.Object.FontFile
+
+        super().__init__(base, size, strings, columns, column_offset, row_offset, use_bounding_box, font)
+
+        self.pointPicked = True
+        self.vobj = vobj
+        self.call = Gui.activeView().addEventCallback("SoEvent", self.action)
+
+    def accept(self):
+        x = App.Units.Quantity(self.form.sbX.text()).Value
+        y = App.Units.Quantity(self.form.sbY.text()).Value
+        z = App.Units.Quantity(self.form.sbZ.text()).Value
+        base = App.Vector(x, y, z)
+
+        size = App.Units.Quantity(self.form.sbHeight.text()).Value
+        strings = self.collectStrings()
+        columns = self.collectColumns()
+        column_offset = App.Units.Quantity(self.form.sbColumnOffset.text()).Value
+        row_offset = App.Units.Quantity(self.form.sbRowOffset.text()).Value
+        use_bounding_box = bool(self.form.cbUseBoundingBox.isChecked())
+        font_file = self.fileSpec
+
+        o = 'FreeCAD.ActiveDocument.getObject("{}")'.format(self.vobj.Object.Name)
+        Gui.doCommand(o + ".Placement.Base=" + toString(base))
+        Gui.doCommand(o + ".Size=" + str(size))
+        Gui.doCommand(o + ".Strings=" + repr(strings))
+        Gui.doCommand(o + ".Columns=" + str(columns))
+        Gui.doCommand(o + ".ColumnOffset=" + str(column_offset))
+        Gui.doCommand(o + ".RowOffset=" + str(row_offset))
+        Gui.doCommand(o + ".UseBoundingBox=" + str(use_bounding_box))
+        Gui.doCommand(o + '.FontFile="' + font_file + '"')
+        Gui.doCommand("FreeCAD.ActiveDocument.recompute()")
+
+        # Persist font used in edit as Shapestring default
+        if not hasattr(self, "_adv_params"):
+            self._adv_params = App.ParamGet(ADV_PARAM_GROUP)
+        self._adv_params.SetString("FontFile", str(font_file))
+
+        self.reject()
+        return True
+
+    def reject(self):
+        self.vobj.Document.resetEdit()
+        self.platWinDialog("Restore")
+        return True
+
+    def finish(self):
+        Gui.activeView().removeEventCallback("SoEvent", self.call)
+        Gui.Snapper.off()
+        Gui.Control.closeDialog()
+        return None

--- a/freecad/ShapeStrings/Grid/Generator.py
+++ b/freecad/ShapeStrings/Grid/Generator.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2009 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2009 Ken Cline <cline@frii.com>
+# SPDX-FileCopyrightText: 2020 FreeCAD Developers
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Provides functions to create GridShapeString objects."""
+
+import FreeCAD as App
+import draftutils.gui_utils as gui_utils
+
+from .Object import GridShapeString
+
+if App.GuiUp:
+    from .View import ViewProviderGridShapeString
+
+
+def make_gridshapestring(Strings, FontFile, Size=100, Columns=3, ColumnOffset=10, RowOffset=15, UseBoundingBox=False):
+    """GridShapeString(Strings,FontFile,[Height],[Columns],[ColumnOffset],[RowOffset],[UseBoundingBox])
+
+    Turns a list of text strings into a single Compound Shape, wrapped onto
+    a 2D grid after the given number of columns, using the given font and
+    separated by the given column/row offsets (optionally using each
+    string's bounding box to size columns/rows instead of a fixed pitch).
+    """
+    App.Console.PrintMessage("Creating GridShapeString object...\n")
+
+    if not App.ActiveDocument:
+        App.Console.PrintError("No active document. Aborting\n")
+        return
+
+    obj = App.ActiveDocument.addObject(
+        "Part::Part2DObjectPython",
+        "GridShapeString"
+    )
+    GridShapeString(obj)
+    # Core grid properties
+    obj.Strings = list(Strings)
+    obj.FontFile = FontFile
+    obj.Size = Size
+    obj.Columns = int(Columns)
+    obj.ColumnOffset = ColumnOffset
+    obj.RowOffset = RowOffset
+    obj.UseBoundingBox = bool(UseBoundingBox)
+
+    # Print all object properties to the FreeCAD console
+    App.Console.PrintMessage("GridShapeString properties:\n")
+    for prop in obj.PropertiesList:
+        try:
+            val = getattr(obj, prop)
+        except Exception as e:
+            val = "<unreadable: {}>".format(e)
+        App.Console.PrintMessage("  {} = {}\n".format(prop, val))
+
+
+    if App.GuiUp:
+        ViewProviderGridShapeString(obj.ViewObject)
+        gui_utils.format_object(obj)
+        obrep = obj.ViewObject
+        if "PointSize" in obrep.PropertiesList:
+            obrep.PointSize = 1
+        gui_utils.select(obj)
+
+    obj.recompute()
+
+    App.Console.PrintMessage("GridShapeString object created successfully.\n")
+    return obj

--- a/freecad/ShapeStrings/Grid/Object.py
+++ b/freecad/ShapeStrings/Grid/Object.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2009 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2009 Ken Cline <cline@frii.com>
+# SPDX-FileCopyrightText: 2020 FreeCAD Developers
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Provides the object code for the GridShapeString object."""
+
+import FreeCAD as App
+import Part
+
+from draftutils.translate import translate
+
+from draftobjects.base import DraftObject
+from ..Misc.StringGeometry import build_string_shape, compute_measured_cap_height
+
+
+class GridShapeString(DraftObject):
+    """The GridShapeString object - renders multiple strings wrapped onto a
+    2D grid of rows and columns."""
+
+    def __init__(self, obj):
+        super().__init__(obj, "GridShapeString")
+        self.set_properties(obj)
+
+    def set_properties(self, obj):
+        """Add properties to the object and set them."""
+        properties = obj.PropertiesList
+
+        if "Strings" not in properties:
+            _tip = translate("App::Property", "List of text strings to render, row-major. A blank entry leaves that grid position empty")
+            obj.addProperty("App::PropertyStringList", "Strings", "Draft", _tip)
+
+        if "Columns" not in properties:
+            _tip = translate("App::Property", "Number of columns before wrapping to a new row")
+            obj.addProperty("App::PropertyInteger", "Columns", "Draft", _tip)
+            obj.Columns = 3
+
+        if "ColumnOffset" not in properties:
+            _tip = translate("App::Property", "Horizontal spacing between columns")
+            obj.addProperty("App::PropertyLength", "ColumnOffset", "Draft", _tip)
+            obj.ColumnOffset = 10.0
+
+        if "RowOffset" not in properties:
+            _tip = translate("App::Property", "Vertical spacing between rows")
+            obj.addProperty("App::PropertyLength", "RowOffset", "Draft", _tip)
+            obj.RowOffset = 15.0
+
+        if "UseBoundingBox" not in properties:
+            _tip = translate("App::Property", "Use each string's bounding box to size columns/rows, adding the column/row offset as the gap")
+            obj.addProperty("App::PropertyBool", "UseBoundingBox", "Draft", _tip)
+            obj.UseBoundingBox = False
+
+        if "FontFile" not in properties:
+            _tip = translate("App::Property", "Font file name")
+            obj.addProperty("App::PropertyFile", "FontFile", "Draft", _tip)
+
+        if "Size" not in properties:
+            _tip = translate("App::Property", "Height of text")
+            obj.addProperty("App::PropertyLength", "Size", "Draft", _tip)
+
+        if "Justification" not in properties:
+            _tip = translate("App::Property", "Horizontal and vertical alignment")
+            obj.addProperty("App::PropertyEnumeration", "Justification", "Draft", _tip)
+            obj.Justification = ["Top-Left", "Top-Center", "Top-Right",
+                                 "Middle-Left", "Middle-Center", "Middle-Right",
+                                 "Bottom-Left", "Bottom-Center", "Bottom-Right"]
+            obj.Justification = "Bottom-Left"
+
+        if "JustificationReference" not in properties:
+            _tip = translate("App::Property", "Height reference used for justification")
+            obj.addProperty("App::PropertyEnumeration", "JustificationReference", "Draft", _tip)
+            obj.JustificationReference = ["Cap Height", "Shape Height"]
+            obj.JustificationReference = "Cap Height"
+
+        if "KeepLeftMargin" not in properties:
+            _tip = translate("App::Property", "Keep left margin and leading white space when justification is left")
+            obj.addProperty("App::PropertyBool", "KeepLeftMargin", "Draft", _tip)
+            obj.KeepLeftMargin = False
+
+        if "ScaleToSize" not in properties:
+            _tip = translate("App::Property", "Scale to ensure cap height is equal to size")
+            obj.addProperty("App::PropertyBool", "ScaleToSize", "Draft", _tip)
+            obj.ScaleToSize = True
+
+        if "Tracking" not in properties:
+            _tip = translate("App::Property", "Inter-character spacing")
+            obj.addProperty("App::PropertyDistance", "Tracking", "Draft", _tip)
+
+        if "ObliqueAngle" not in properties:
+            _tip = translate("App::Property", "Oblique (slant) angle")
+            obj.addProperty("App::PropertyAngle", "ObliqueAngle", "Draft", _tip)
+
+        if "MakeFace" not in properties:
+            _tip = translate("App::Property", "Fill letters with faces")
+            obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
+            obj.MakeFace = True
+
+        if "Fuse" not in properties:
+            _tip = translate("App::Property", "Fuse faces if faces overlap, usually not required (can be very slow)")
+            obj.addProperty("App::PropertyBool", "Fuse", "Draft", _tip)
+            obj.Fuse = False
+
+    def onDocumentRestored(self, obj):
+        super().onDocumentRestored(obj)
+        # Ensure all properties exist after document restoration
+        self.set_properties(obj)
+
+    def execute(self, obj):
+        """Generate the compound shape from the list of strings, wrapped onto a grid."""
+        if self.props_changed_placement_only():
+            obj.positionBySupport()
+            self.props_changed_clear()
+            return
+
+        if obj.Strings and obj.FontFile:
+            plm = obj.Placement
+            columns = max(1, int(obj.Columns))
+
+            measured_cap_height = compute_measured_cap_height(obj.FontFile, obj.Size, obj.Tracking)
+            justification_cap_height = obj.Size if obj.ScaleToSize else measured_cap_height
+
+            # Render every string once, remembering which grid cell (row,
+            # col) it belongs to. A blank string still consumes a cell -
+            # that's what lets a grid have gaps instead of being a flat
+            # list of only non-empty entries like SpacedShapeString.
+            cells = []
+            max_row = -1
+            for index, string_text in enumerate(obj.Strings):
+                row = index // columns
+                col = index % columns
+                max_row = max(max_row, row)
+
+                shapes = build_string_shape(
+                    string_text,
+                    obj.FontFile,
+                    obj.Size,
+                    obj.Tracking,
+                    obj.MakeFace,
+                    obj.Fuse,
+                    obj.ScaleToSize,
+                    measured_cap_height,
+                    obj.ObliqueAngle,
+                    obj.Justification,
+                    obj.JustificationReference,
+                    obj.KeepLeftMargin,
+                    justification_cap_height,
+                )
+                if shapes:
+                    bbox = Part.Compound(shapes).optimalBoundingBox()
+                    cells.append((row, col, shapes, bbox))
+
+            if cells:
+                column_offset = float(obj.ColumnOffset)
+                row_offset = float(obj.RowOffset)
+
+                if obj.UseBoundingBox:
+                    col_width = {}
+                    row_height = {}
+                    for row, col, _shapes, bbox in cells:
+                        col_width[col] = max(col_width.get(col, 0.0), bbox.XLength)
+                        row_height[row] = max(row_height.get(row, 0.0), bbox.YLength)
+
+                    col_x = {}
+                    cursor = 0.0
+                    for col in range(columns):
+                        col_x[col] = cursor
+                        cursor += col_width.get(col, 0.0) + column_offset
+
+                    row_y = {}
+                    cursor = 0.0
+                    for row in range(max_row + 1):
+                        row_y[row] = cursor
+                        cursor -= row_height.get(row, 0.0) + row_offset
+                else:
+                    col_x = {col: col * column_offset for col in range(columns)}
+                    # Row 0 is the first entry in Strings and sits at the
+                    # insertion point; later rows step in -Y so the grid
+                    # reads top-to-bottom like the Strings list itself.
+                    row_y = {row: -row * row_offset for row in range(max_row + 1)}
+
+                all_shapes = []
+                for row, col, shapes, _bbox in cells:
+                    offset_vec = App.Vector(col_x[col], row_y[row], 0)
+                    for shape in shapes:
+                        shape.translate(offset_vec)
+                    all_shapes.extend(shapes)
+
+                obj.Shape = Part.Compound(all_shapes)
+            else:
+                App.Console.PrintWarning(translate("draft", "GridShapeString: strings have no wires") + "\n")
+
+            obj.Placement = plm
+
+        obj.positionBySupport()
+        self.props_changed_clear()
+
+    def onChanged(self, obj, prop):
+        self.props_changed_store(prop)

--- a/freecad/ShapeStrings/Grid/View.py
+++ b/freecad/ShapeStrings/Grid/View.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2022 Mario Passaglia
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Provides the viewprovider code for the GridShapeString object."""
+
+
+import FreeCADGui as Gui
+
+from draftviewproviders.view_base import ViewProviderDraft
+from ..Misc.Resources import asIcon
+from .Dialog import GridShapeStringTaskPanelEdit
+
+class ViewProviderGridShapeString(ViewProviderDraft):
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def getIcon(self):
+        return asIcon('Grid')
+
+    def updateData(self, obj, prop):
+        if (prop == "Strings" or
+            prop == "FontFile" or
+            prop == "Size" or
+            prop == "Columns" or
+            prop == "ColumnOffset" or
+            prop == "RowOffset" or
+            prop == "UseBoundingBox"):
+            obj.recompute()
+
+        return
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        # Using Draft_Edit to detect if the Draft, Arch or BIM WB has been loaded.
+        if "Draft_Edit" not in Gui.listCommands():
+            self.wb_before_edit = Gui.activeWorkbench()
+            Gui.activateWorkbench("DraftWorkbench")
+
+        self.task = GridShapeStringTaskPanelEdit(vobj)
+        Gui.Control.showDialog(self.task)
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        self.task.finish()
+        if hasattr(self, "wb_before_edit"):
+            Gui.activateWorkbench(self.wb_before_edit.name())
+            delattr(self, "wb_before_edit")
+        return True

--- a/freecad/ShapeStrings/Grid/__init__.py
+++ b/freecad/ShapeStrings/Grid/__init__.py
@@ -1,0 +1,2 @@
+
+from .Command import registerGrid

--- a/freecad/ShapeStrings/Misc/StringGeometry.py
+++ b/freecad/ShapeStrings/Misc/StringGeometry.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2009 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2009 Ken Cline <cline@frii.com>
+# SPDX-FileCopyrightText: 2020 FreeCAD Developers
+# SPDX-FileCopyrightText: 2025 Robert Massaioli
+# SPDX-FileNotice: Part of the ShapeStrings addon.
+
+################################################################################
+#                                                                              #
+#   This library is free software; you can redistribute it and/or modify it    #
+#   under the terms of the GNU Lesser General Public License as published      #
+#   by the Free Software Foundation; either version 2.1 of the License, or     #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This library is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                       #
+#                                                                              #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public License   #
+#   along with this library; if not, write to the Free Software Foundation,    #
+#   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA           #
+#                                                                              #
+################################################################################
+
+"""Shared single-string rendering helpers, used by GridShapeString.
+
+This factors out the wire -> face -> scale -> oblique -> justify pipeline
+that SpacedShapeString and RadialShapeString each carry their own copy of
+(see `Spaced/Object.py` and `Radial/Object.py`), so GridShapeString does not
+need a third copy.
+
+Spaced/Radial are intentionally left as-is rather than retrofitted onto this
+helper: their local copies compute `cap_height` and then overwrite it with
+`obj.Size` *before* using it as the scale divisor, which makes `ScaleToSize`
+a no-op (scale factor `obj.Size / obj.Size == 1.0`) in both objects. This
+helper follows FreeCAD upstream's ordering instead (see
+`Draft/draftobjects/shapestring.py`), which scales using the *measured* cap
+height and only substitutes `obj.Size` afterwards for the justification
+reference. Reusing this helper for Spaced/Radial would therefore change the
+rendered geometry of existing saved documents - out of scope for adding a
+grid layout tool, so it is left for a separate, deliberate follow-up.
+"""
+
+import math
+
+import FreeCAD as App
+import Part
+
+from draftgeoutils import faces as draft_faces
+from draftutils.translate import translate
+
+from .Justify import justification_vector
+
+
+def compute_measured_cap_height(font_file, size, tracking):
+    """Return the unscaled cap height (Y max) of a rendered 'M' glyph."""
+    cap_char = Part.makeWireString("M", font_file, size, tracking)[0]
+    return Part.Compound(cap_char).BoundBox.YMax
+
+
+def make_faces(wire_char):
+    """Create faces from a wire character representation.
+
+    Tries FaceMakerBullseye, then Cheese, then Simple - the same fallback
+    chain used by Spaced/Radial's own `make_faces()` and by upstream
+    `ShapeString.make_faces()`.
+    """
+    wrn = translate("draft", "GridShapeString: face creation failed for one character") + "\n"
+
+    wirelist = []
+    for w in wire_char:
+        comp_edges = Part.Compound(w.Edges)
+        comp_edges = comp_edges.connectEdgesToWires()
+        if comp_edges.Wires[0].isClosed():
+            wirelist.append(comp_edges.Wires[0])
+
+    if not wirelist:
+        App.Console.PrintWarning(wrn)
+        return []
+
+    built_faces = None
+    for face_maker in ("Part::FaceMakerBullseye", "Part::FaceMakerCheese", "Part::FaceMakerSimple"):
+        try:
+            candidate = Part.makeFace(wirelist, face_maker).Faces
+            for face in candidate:
+                face.validate()
+            built_faces = candidate
+            break
+        except Part.OCCError:
+            continue
+
+    if built_faces is None:
+        App.Console.PrintWarning(wrn)
+        return []
+
+    for face in built_faces:
+        try:
+            if face.normalAt(0, 0).z < 0:
+                face.reverse()
+        except Exception:
+            pass
+
+    return built_faces
+
+
+def build_string_shape(
+    string_text,
+    font_file,
+    size,
+    tracking,
+    make_face,
+    fuse,
+    scale_to_size,
+    measured_cap_height,
+    oblique_angle,
+    justification,
+    justification_reference,
+    keep_left_margin,
+    justification_cap_height,
+):
+    """Render a single string into a positioned, justified list of shapes.
+
+    Mirrors the per-string pipeline in SpacedShapeString/RadialShapeString's
+    `execute()`: wire generation, optional face fill, scale, oblique shear,
+    then justification. Returns a list of `Part` shapes local to the
+    string's own origin (not yet translated to a grid position), or an
+    empty list if the string produced no usable geometry.
+    """
+    if not string_text:
+        return []
+
+    fill = make_face
+    if fill is True:
+        # Test a simple letter to know if we have a sticky font or not.
+        char = Part.makeWireString("L", font_file, 1, 0)[0]
+        probe_shapes = make_faces(char)
+        if not probe_shapes:
+            fill = False
+        else:
+            # The area threshold is scaled by glyph size so it behaves
+            # consistently across fonts/sizes (FreeCAD issue #21501).
+            char_comp = Part.Compound(char)
+            factor = 1 / char_comp.BoundBox.YLength
+            fill = sum(shape.Area for shape in probe_shapes) > (0.03 / factor**2) and math.isclose(
+                char_comp.BoundBox.DiagonalLength,
+                Part.Compound(probe_shapes).BoundBox.DiagonalLength,
+                rel_tol=1e-7,
+            )
+
+    chars = Part.makeWireString(string_text, font_file, size, tracking)
+    string_shapes = []
+    for char in chars:
+        if fill is False:
+            string_shapes.extend(char)
+        elif char:
+            string_shapes.extend(make_faces(char))
+
+    if not string_shapes:
+        return []
+
+    if fill and fuse:
+        ss_shape = string_shapes[0].fuse(string_shapes[1:])
+        ss_shape = draft_faces.concatenate(ss_shape)
+        # concatenate() can collapse a single-face compound into a bare
+        # Face, but the code below relies on `.SubShapes`.
+        if ss_shape.ShapeType == "Face":
+            ss_shape = Part.Compound([ss_shape])
+    else:
+        ss_shape = Part.Compound(string_shapes)
+
+    if scale_to_size:
+        ss_shape.scale(size / measured_cap_height)
+
+    if oblique_angle:
+        if -80 <= oblique_angle <= 80:
+            mtx = App.Matrix()
+            mtx.A12 = math.tan(math.radians(oblique_angle))
+            ss_shape = ss_shape.transformGeometry(mtx)
+        else:
+            wrn = translate("draft", "GridShapeString: oblique angle must be in the -80 to +80 degree range") + "\n"
+            App.Console.PrintWarning(wrn)
+
+    just_vec = justification_vector(
+        ss_shape,
+        justification_cap_height,
+        justification,
+        justification_reference,
+        keep_left_margin,
+    )
+    shapes = ss_shape.SubShapes
+    for shape in shapes:
+        shape.translate(just_vec)
+
+    return shapes

--- a/freecad/ShapeStrings/Misc/Toolbar.py
+++ b/freecad/ShapeStrings/Misc/Toolbar.py
@@ -14,11 +14,17 @@ class Manipulator:
             'toolBar' : draft_creation_1_0,
             'append' : 'ShapeStrings_Radial'
         },{
+            'toolBar' : draft_creation_1_0,
+            'append' : 'ShapeStrings_Grid'
+        },{
             'toolBar' : draft_creation_1_1,
             'append' : 'ShapeStrings_Spaced'
         },{
             'toolBar' : draft_creation_1_1,
             'append' : 'ShapeStrings_Radial'
+        },{
+            'toolBar' : draft_creation_1_1,
+            'append' : 'ShapeStrings_Grid'
         }]
 
 

--- a/freecad/ShapeStrings/Resources/Icons/Grid.svg
+++ b/freecad/ShapeStrings/Resources/Icons/Grid.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg4594"
+   height="64px"
+   width="64px">
+
+  <defs
+     id="defs4596">
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         id="stop3813"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3815"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3788">
+      <stop
+         id="stop3790"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3792"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="11.793966"
+       x2="20.47628"
+       y1="50.470772"
+       x1="36.046734"
+       id="linearGradient3794"
+       xlink:href="#linearGradient3788" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="11.339914"
+       x2="31.328201"
+       y1="57.876183"
+       x1="43.087261"
+       id="linearGradient3817"
+       xlink:href="#linearGradient3811" />
+    <!-- Base S icon content, wrapped and scaled down once -->
+    <g id="Sbase" transform="scale(0.3)">
+      <g
+         transform="matrix(1.0012484,0,0,1.2260559,45.70983,21.37906)"
+         style="fill:#fce94f;stroke:#302b00;stroke-width:1.80511105000000010"
+         id="g4061">
+        <g
+           id="text3103"
+           style="font-size:80.06713104000000700px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;color:#000000;stroke:#302b00;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Times New Roman;-inkscape-font-specification:'Times New Roman, Italic';fill:#fce94f"
+           transform="scale(1.258685,0.79447996)">
+          <path
+             id="path2997"
+             style="stroke:#302b00;marker:none;fill:#fce94f"
+             d="m -32.302817,38.622148 4.378671,-19.664925 1.32924,0 c -0.182451,1.902653 -0.273673,3.479495 -0.273667,4.730529 -6e-6,3.570712 1.140271,6.476791 3.420836,8.718247 2.280547,2.241465 5.258301,3.362195 8.933272,3.362194 3.414299,1e-6 6.0076165,-1.049054 7.7799602,-3.14717 1.7722914,-2.098107 2.6584502,-4.515496 2.658479,-7.252174 -2.88e-5,-1.772306 -0.404013,-3.388243 -1.2119537,-4.847815 -1.2250117,-2.163253 -4.4959801,-5.968523 -9.8129145,-11.4158215 -2.580304,-2.606321 -4.235336,-4.5480512 -4.965101,-5.8251965 -1.198933,-2.1111088 -1.798394,-4.3265058 -1.798383,-6.6461974 -1.1e-5,-3.7009753 1.381354,-6.8676896 4.1441,-9.5001526 2.762715,-2.632363 6.30735,-3.948569 10.6339157,-3.948623 1.4595298,5.4e-5 2.840895,0.143403 4.1440995,0.430048 0.8079384,0.156434 2.28052579,0.677704 4.4177666,1.563811 1.5116482,0.599512 2.34568,0.925306 2.5020978,0.977382 0.3648521,0.07824 0.7688362,0.117337 1.2119536,0.117286 0.7558033,5.1e-5 1.4073906,-0.195425 1.954764,-0.586429 0.5472933,-0.390901 1.1858489,-1.224933 1.9156686,-2.502098 l 1.4856202,0 -4.0659086,17.59287513 -1.3292394,0 C 5.2546759,-0.78585482 5.3068029,-2.0499342 5.3068411,-3.0143239 5.3068029,-6.1679662 4.2642632,-8.748252 2.1792188,-10.755189 c -2.08511451,-2.006841 -4.834813,-3.010285 -8.2491039,-3.010337 -2.71063,5.2e-5 -4.9129949,0.794988 -6.6071019,2.384812 -1.694147,1.5899223 -2.541211,3.4273986 -2.541193,5.5124347 -1.8e-5,1.8244878 0.5408,3.564226 1.622454,5.21921976 1.081615,1.65506984 3.570679,4.35264144 7.467198,8.09272274 3.8964655,3.7401408 6.41810849,6.6592528 7.5649365,8.7573428 1.1467594,2.098132 1.7201562,4.333077 1.7201922,6.70484 -3.6e-5,2.684554 -0.7102662,5.284388 -2.1306927,7.799508 -1.42049421,2.515134 -3.4599625,4.46338 -6.1184111,5.844744 -2.6585041,1.381366 -5.5645839,2.072049 -8.7182469,2.07205 -1.563829,-1e-6 -3.023385,-0.14335 -4.378672,-0.430048 -1.355316,-0.286699 -3.518586,-0.990414 -6.489816,-2.111145 -1.016484,-0.390951 -1.863548,-0.586427 -2.541193,-0.586429 -1.537752,2e-6 -2.736672,1.042541 -3.596766,3.127622 z" />
+        </g>
+      </g>
+
+      <text
+         id="text3097"
+         y="19.773684"
+         x="15.684914"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#edd400;fill-opacity:1;stroke:#302b00;stroke-width:2"
+         xml:space="preserve">
+        <tspan
+           style="font-size:40px;line-height:1.25;font-family:sans-serif"
+           y="19.773684"
+           x="15.684914"
+           id="tspan3099"> </tspan>
+      </text>
+
+      <path
+         id="path2997-0"
+         d="m 29.3519,8.1347804 c -6.562684,1.410881 -12.046817,9.5244946 -7.125,15.3437496 6.101664,7.122025 16.730075,11.103607 20.25,20.375 1.126065,4.464765 -1.197115,9.158945 -4.84375,11.71875 7.159093,-1.69687 13.379117,-10.628 8.40625,-17.25 -5.88152,-7.936101 -17.468774,-10.974591 -21.125,-20.625 -1.1145,-3.968568 1.528727,-7.9065687 4.90625,-9.7187496 z M 55.421432,9.446023 c -1.454337,1.571174 -6.612341,-0.6947496 -3.340117,1.766067 1.949211,2.859194 1.686574,5.783269 2.487426,0.446825 0.281039,-0.770956 1.351842,-2.274891 0.852691,-2.212892 z M 8.4769001,54.72853 c 1.6840469,-1.546034 6.5798229,0.09763 5.9374999,-0.6875 -1.89754,-1.615914 -3.316472,-3.755951 -3.96875,-6.15625 -0.6562499,2.28125 -1.3124999,4.5625 -1.9687499,6.84375 z"
+         style="font-size:80.06713104000000700px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;color:#000000;fill:url(#linearGradient3817);stroke:#fce94f;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Times New Roman;-inkscape-font-specification:'Times New Roman, Italic';fill-opacity:1" />
+    </g>
+  </defs>
+
+  <g id="layer1" transform="translate(2,4)">
+
+    <!-- 2x2 grid: 4 translated copies of the scaled base, two rows -->
+    <!-- top row -->
+    <g transform="translate(0,0)">
+      <use xlink:href="#Sbase" />
+    </g>
+    <g transform="translate(28,0)">
+      <use xlink:href="#Sbase" />
+    </g>
+
+    <!-- bottom row -->
+    <g transform="translate(0,26)">
+      <use xlink:href="#Sbase" />
+    </g>
+    <g transform="translate(28,26)">
+      <use xlink:href="#Sbase" />
+    </g>
+
+  </g>
+
+  <metadata
+     id="metadata5540">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Mon Apr 15 13:25:25 2013 -0400</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[WandererFan]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_ShapeString.svg</dc:identifier>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>S</rdf:li>
+            <rdf:li>letter</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A capital letter S, slightly italicized, repeated in a 2x2 grid</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/freecad/ShapeStrings/Resources/Interfaces/Grid.ui
+++ b/freecad/ShapeStrings/Resources/Interfaces/Grid.ui
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DraftGridShapeStringGui</class>
+ <widget class="QWidget" name="DraftGridShapeStringGui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>445</width>
+    <height>620</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>GridShapeString</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout_7">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelX">
+       <property name="text">
+        <string>X</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbX">
+       <property name="toolTip">
+        <string>Enter coordinates or pick a point with the mouse</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelY">
+       <property name="text">
+        <string>Y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbY">
+       <property name="toolTip">
+        <string>Enter coordinates or pick a point with the mouse</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelZ">
+       <property name="text">
+        <string>Z</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbZ">
+       <property name="toolTip">
+        <string>Enter coordinates or pick a point with the mouse</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="cbGlobalMode">
+       <property name="toolTip">
+        <string>Coordinates relative to global coordinate system.
+Uncheck to use working plane coordinate system</string>
+       </property>
+       <property name="text">
+        <string>Global</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QPushButton" name="pbReset">
+       <property name="toolTip">
+        <string>Resets the picked point</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Reset Point</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelHeight">
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbHeight">
+       <property name="toolTip">
+        <string>Height of the result</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="gridLayout_6">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelColumns">
+       <property name="text">
+        <string>Columns</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="sbColumns">
+       <property name="toolTip">
+        <string>Number of columns before wrapping to a new row</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999</number>
+       </property>
+       <property name="value">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelStrings">
+       <property name="text">
+        <string>Strings</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QTableWidget" name="tableStrings">
+       <property name="toolTip">
+        <string>Grid of text strings to render, one cell per grid position. Leave a cell blank to skip that position. Double-click a cell to edit it.</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="2" column="1">
+      <layout class="QHBoxLayout" name="layoutRowButtons">
+       <item>
+        <widget class="QPushButton" name="pbAddRow">
+         <property name="text">
+          <string>Add Row</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pbRemoveRow">
+         <property name="text">
+          <string>Remove Row</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelColumnOffset">
+       <property name="text">
+        <string>Column Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbColumnOffset">
+       <property name="toolTip">
+        <string>Horizontal spacing offset between columns</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelRowOffset">
+       <property name="text">
+        <string>Row Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::QuantitySpinBox" name="sbRowOffset">
+       <property name="toolTip">
+        <string>Vertical spacing offset between rows</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>15.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QCheckBox" name="cbUseBoundingBox">
+       <property name="toolTip">
+        <string>Use each string's bounding box to size columns/rows, adding the column/row offset as the gap</string>
+       </property>
+       <property name="text">
+        <string>Use Bounding Box for Spacing</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelFontFile">
+       <property name="text">
+        <string>Font file</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="Gui::FileChooser" name="fcFontFile">
+       <property name="filter">
+        <string>Font files (*.ttc *.ttf *.otf *.pfb *.TTC *.TTF *.OTF *.PFB)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <connections/>
+</ui>

--- a/freecad/ShapeStrings/Resources/Interfaces/Grid.ui
+++ b/freecad/ShapeStrings/Resources/Interfaces/Grid.ui
@@ -138,7 +138,7 @@ Uncheck to use working plane coordinate system</string>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QSpinBox" name="sbColumns">
+      <widget class="Gui::IntSpinBox" name="sbColumns">
        <property name="toolTip">
         <string>Number of columns before wrapping to a new row</string>
        </property>
@@ -278,6 +278,11 @@ Uncheck to use working plane coordinate system</string>
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::IntSpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/SpinBox.h</header>
   </customwidget>
  </customwidgets>
  <connections/>

--- a/freecad/ShapeStrings/init_gui.py
+++ b/freecad/ShapeStrings/init_gui.py
@@ -5,6 +5,7 @@ from .Misc.Resources import paths
 from .Misc.Toolbar import extendToolbar
 from .Spaced import registerSpaced
 from .Radial import registerRadial
+from .Grid import registerGrid
 from .API import initializeAPI
 
 from FreeCAD import Gui
@@ -16,5 +17,6 @@ initializeAPI()
 
 registerRadial()
 registerSpaced()
+registerGrid()
 
 extendToolbar()


### PR DESCRIPTION
## Summary

Closes #9. Implements **Option B** from `AI-planning/issue-09-grid-columns-interline-spacing.md`: a dedicated `Grid/` module alongside the existing `Spaced/` and `Radial/` tools, rather than extending `SpacedShapeString` in place.

- New `GridShapeString` object (`Grid/Object.py`) with `Strings` (row-major), `Columns`, `ColumnOffset`, `RowOffset`, `UseBoundingBox`, plus the same text-rendering properties as `Spaced`/`Radial`.
- A **blank `Strings` entry still reserves its grid position** — this lets a grid have gaps (e.g. an L-shaped layout of labelled tiles) instead of collapsing into a flat list of only non-empty entries the way `SpacedShapeString` does.
- Purpose-built task panel (`Grid/Dialog.py` + `Resources/Interfaces/Grid.ui`) with a genuine 2D table for entering strings, which reshapes live as the `Columns` spin box changes, plus `Add Row`/`Remove Row` controls — rather than reusing a flat list widget.
- New toolbar command, icon (`Resources/Icons/Grid.svg`), and docs (`Documentation/Commands/Grid.md`, plus `API.md`/`README.md` updates).
- `SpacedShapeString` and `RadialShapeString` are **untouched** — zero regression risk for existing saved documents, per Option B's stated tradeoff vs. Option A.

### A shared rendering helper, and a pre-existing bug it deliberately does not "fix" in place

The per-string wire → face → scale → oblique → justify pipeline that `Spaced/Object.py` and `Radial/Object.py` each carry their own copy of is factored into a new `Misc/StringGeometry.py`, used by `Grid`.

While building it I found that both `Spaced` and `Radial` compute `cap_height` from the rendered glyph and then immediately overwrite it with `obj.Size` *before* using it as the scale divisor (`ss_shape.scale(obj.Size / cap_height)` where `cap_height == obj.Size`). That makes `ScaleToSize` a no-op in both objects today. Upstream FreeCAD's `Draft/draftobjects/shapestring.py` scales using the *measured* cap height first, then substitutes `obj.Size` afterwards only for the justification reference — `StringGeometry.py` follows that correct ordering, so `GridShapeString.ScaleToSize` actually scales.

I deliberately did **not** retrofit `Spaced`/`Radial` onto this helper in this PR: doing so would silently change the rendered geometry of existing saved documents, which is exactly the kind of regression Option B was chosen to avoid. That retrofit (and fixing the `ScaleToSize` no-op there) is left as a separate, explicit follow-up.

Two other small upstream fixes were pulled into the new helper since they were free to include (new code, no regression risk vs. the copies in `Spaced`/`Radial`):
- Guard against `draftgeoutils.faces.concatenate()` collapsing a single-face compound into a bare `Face` (upstream's `ShapeString.execute()` has this guard; the addon's copies don't).
- Scale the sticky-font area-detection threshold by glyph size (FreeCAD issue #21501), instead of the old fixed `0.03` threshold.

### Grid layout math

- `UseBoundingBox = False` (default): fixed pitch, `col_x = col * ColumnOffset`, `row_y = -row * RowOffset`.
- `UseBoundingBox = True`: each column is sized to its widest rendered string, each row to its tallest, with the offset added as the gap on top — independent per axis, computed from each string's `optimalBoundingBox()`.
- Rows step in `-Y` as `Strings` index increases, so the grid reads top-to-bottom in the same order as the list.

No version bump included — left for the maintainer's judgment per repo convention (`bump_version.py` documents *how*, not that every feature PR should bump).

## Test plan

There's no headless test runner for this FreeCAD addon (see `AGENTS.md`); it only runs inside FreeCAD's `Mod/` directory. Since FreeCAD itself isn't available in this environment:

- [x] `python3 -m py_compile` on every `.py` file in `freecad/ShapeStrings/` (new and pre-existing) — all compile.
- [x] New `.ui` and `.svg` files validated as well-formed XML.
- [x] New `Grid.svg` icon rendered to PNG via `cairosvg` to confirm the 2x2 grid glyphs don't overlap.
- [x] Grid row/column placement math (fixed-pitch, bounding-box sizing, gap handling via blank `Strings` entries, single-cell and empty-list edge cases) verified against a standalone re-implementation of the non-FreeCAD-dependent arithmetic in `Grid/Object.py`'s `execute()`.
- [ ] Manual verification inside FreeCAD (symlink `freecad/ShapeStrings` into `Mod/`, create a `Grid ShapeString`, edit it, save/reload the document) — **not done, needs a human with a FreeCAD install** to confirm the task panel and rendering behave as intended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)